### PR TITLE
Fixes #1

### DIFF
--- a/rrule.js
+++ b/rrule.js
@@ -130,7 +130,8 @@ var dateutil = {
         var millisecsFromBase = ordinal * dateutil.ONE_DAY;
         return new Date(dateutil.ORDINAL_BASE.getTime()
                         - dateutil.tzOffset(dateutil.ORDINAL_BASE)
-                        +  millisecsFromBase);
+                        +  millisecsFromBase
+                        + dateutil.tzOffset(new Date(millisecsFromBase)));
     },
 
     /**


### PR DESCRIPTION
"millisecsFromBase" is already in local time when creating a new Date object.
By adding the timezone offset to millisecsFromBase, the issue seems to be
fixed and all tests pass.
