### PR TITLE
Fix for incorrect removal of extra day in Feb for non-leap years in NMDAY365MASK

### DIFF
--- a/rrule.js
+++ b/rrule.js
@@ -369,7 +369,7 @@ var WDAYMASK = (function() {
 M29 = M30 = M31 = null;
 M365MASK = M365MASK.slice(0, 58).concat(M365MASK.slice(59, M365MASK.length));
 MDAY365MASK = MDAY365MASK.slice(0, 58).concat(MDAY365MASK.slice(59));
-NMDAY365MASK = NMDAY365MASK.slice(0, 30).concat(NMDAY365MASK.slice(31));
+NMDAY365MASK = NMDAY365MASK.slice(0, 31).concat(NMDAY365MASK.slice(32));
 
 
 //=============================================================================

--- a/test/tests.js
+++ b/test/tests.js
@@ -755,6 +755,24 @@ testRecurring('testMonthlyBySetPos', new RRule(RRule.MONTHLY, {
         datetime(1997, 9, 17, 6, 0),
         datetime(1997, 10, 13, 18, 0)]);
 
+testRecurring('testMonthlyNegByMonthDayJanFebForNonLeapYear', new RRule(RRule.MONTHLY, {
+    count: 4,
+    bymonthday: -1,
+    dtstart: parse("20131201T0900000")}),
+    [datetime(2013, 12, 31, 9, 0),
+        datetime(2014, 1, 31, 9, 0),
+        datetime(2014, 2, 28, 9, 0),
+        datetime(2014, 3, 31, 9, 0)]);
+
+testRecurring('testMonthlyNegByMonthDayJanFebForLeapYear', new RRule(RRule.MONTHLY, {
+    count: 4,
+    bymonthday: -1,
+    dtstart: parse("20151201T0900000")}),
+    [datetime(2015, 12, 31, 9, 0),
+        datetime(2016, 1, 31, 9, 0),
+        datetime(2016, 2, 29, 9, 0),
+        datetime(2016, 3, 31, 9, 0)]);
+
 testRecurring('testWeekly', new RRule(RRule.WEEKLY, {
     count:3,
     dtstart:parse("19970902T090000")}),


### PR DESCRIPTION
Noticed a problem when generating rules for the last day of the month across a new year. Tracked down the problem to an off by one error when removing the extra day in Feb for non-leap years. Added tests.
