### PR TITLE
Use error object for exceptions

### DIFF
--- a/lib/nlp.js
+++ b/lib/nlp.js
@@ -34,7 +34,7 @@ if (serverSide) {
     if (!RRule) {RRule = require('rrule');}
     if (!_ && (typeof require !== 'undefined')) { _ = require('underscore');}
 } else {
-    throw 'rrule.js and underscore.js are required for rrule/nlp.js to work'
+    throw new Error('rrule.js and underscore.js are required for rrule/nlp.js to work')
 }
 
 
@@ -568,7 +568,7 @@ var parseText = function(text, language) {
             options.interval = parseInt(n[0]);
 
         if(ttr.isDone())
-            throw 'Unexpected end';
+            throw new Error('Unexpected end');
 
         switch(ttr.symbol) {
         case 'day(s)':
@@ -634,12 +634,12 @@ var parseText = function(text, language) {
             // TODO check for duplicates
             while (ttr.accept('comma')) {
                 if(ttr.isDone())
-                    throw 'Unexpected end';
+                    throw new Error('Unexpected end');
 
                 var wkd;
                 if(!(wkd = decodeWKD())) {
-                    throw 'Unexpected symbol ' + ttr.symbol
-                        + ', expected weekday';
+                    throw new Error('Unexpected symbol ' + ttr.symbol
+                        + ', expected weekday');
                 }
 
                 options.byweekday.push(RRule[wkd]);
@@ -670,12 +670,12 @@ var parseText = function(text, language) {
             // TODO check for duplicates
             while (ttr.accept('comma')) {
                 if(ttr.isDone())
-                    throw 'Unexpected end';
+                    throw new Error('Unexpected end');
 
                 var m;
                 if(!(m = decodeM())) {
-                    throw 'Unexpected symbol ' + ttr.symbol
-                        + ', expected month';
+                    throw new Error('Unexpected symbol ' + ttr.symbol
+                        + ', expected month');
                 }
 
                 options.bymonth.push(m);
@@ -687,7 +687,7 @@ var parseText = function(text, language) {
             break;
 
         default:
-            throw 'Unknown symbol';
+            throw new Error('Unknown symbol');
 
         }
     }
@@ -741,14 +741,14 @@ var parseText = function(text, language) {
                 ttr.nextSymbol();
                 var n;
                 if(!(n = ttr.accept('number'))) {
-                    throw 'Unexpected symbol ' + ttr.symbol
-                        + ', expected week number';
+                    throw new Error('Unexpected symbol ' + ttr.symbol
+                        + ', expected week number');
                 }
                 options.byweekno = [n[0]];
                 while(ttr.accept('comma')) {
                     if(!(n = ttr.accept('number'))) {
-                        throw 'Unexpected symbol ' + ttr.symbol
-                            + '; expected monthday';
+                        throw new Error('Unexpected symbol ' + ttr.symbol
+                            + '; expected monthday');
                     }
                     options.byweekno.push(n[0]);
                 }
@@ -831,7 +831,7 @@ var parseText = function(text, language) {
         case 'nth':
             var v = parseInt(ttr.value[1]);
             if(v < -366 || v > 366)
-                throw 'Nth out of range: ' + v;
+                throw new Error('Nth out of range: ' + v);
 
             ttr.nextSymbol();
             return ttr.accept('last') ? -v : v;
@@ -857,8 +857,8 @@ var parseText = function(text, language) {
         while(ttr.accept('comma')) {
 
             if (!(nth = decodeNTH())) {
-                throw 'Unexpected symbol ' + ttr.symbol
-                        + '; expected monthday';
+                throw new Error('Unexpected symbol ' + ttr.symbol
+                        + '; expected monthday');
             }
 
             options.bymonthday.push(nth);
@@ -874,7 +874,7 @@ var parseText = function(text, language) {
             var date = Date.parse(ttr.text);
 
             if (!date) {
-                throw 'Cannot parse until date:' + ttr.text;
+                throw new Error('Cannot parse until date:' + ttr.text);
             }
             options.until = new Date(date);
         } else if(ttr.accept('for')){
@@ -969,7 +969,7 @@ Parser.prototype.expect = function(name) {
        return true;
    }
 
-   throw 'expected ' + name + ' but found ' + this.symbol;
+   throw new Error('expected ' + name + ' but found ' + this.symbol);
 };
 
 


### PR DESCRIPTION
When throwing an exception just by string, then `stack` is not available.
