### PR TITLE
Fixed export in nlp.js

### DIFF
--- a/lib/nlp.js
+++ b/lib/nlp.js
@@ -1064,7 +1064,7 @@ if (serverSide) {
 if (typeof define === "function" && define.amd) {
     /*global define:false */
     define("rrule", [], function () {
-        return RRule;
+        return nlp;
     });
 }
 


### PR DESCRIPTION
This causes Webpack to fail. I already have to manually patch RRule in order to get to/fromText working within Webpack. Example:

```javascript
import RRule from 'rrule';
RRule.RRule = RRule;
let nlp = require('rrule/lib/nlp');

RRule.prototype.toText = function (gettext, language) {
  return nlp.toText(this, gettext, language);
};

RRule.prototype.fromText = function (text, language) {
  return nlp.fromText(text, language);
};
```