### PR TITLE
Bugfix - Apply dtstart option when forceset: true

### DIFF
--- a/src/rrulestr.ts
+++ b/src/rrulestr.ts
@@ -114,13 +114,13 @@ function buildRule (s: string, options: Partial<RRuleStrOptions>) {
   ) {
     const rset = new RRuleSet(noCache)
 
-    rset.dtstart(dtstart)
+    rset.dtstart(options.dtstart || dtstart)
     rset.tzid(tzid || undefined)
 
     rrulevals.forEach(val => {
       rset.rrule(
         new RRule(
-          groomRruleOptions(val, dtstart, tzid),
+          groomRruleOptions(val, options.dtstart || dtstart, tzid),
           noCache
         )
       )
@@ -133,7 +133,7 @@ function buildRule (s: string, options: Partial<RRuleStrOptions>) {
     exrulevals.forEach(val => {
       rset.exrule(
         new RRule(
-          groomRruleOptions(val, dtstart, tzid),
+          groomRruleOptions(val, options.dtstart || dtstart, tzid),
           noCache
         )
       )
@@ -143,7 +143,7 @@ function buildRule (s: string, options: Partial<RRuleStrOptions>) {
       rset.exdate(date)
     })
 
-    if (options.compatible && options.dtstart) rset.rdate(dtstart!)
+    if (options.compatible && options.dtstart) rset.rdate((options.dtstart || dtstart))
     return rset
   }
 

--- a/test/rrulestr.test.ts
+++ b/test/rrulestr.test.ts
@@ -288,6 +288,36 @@ describe('rrulestr', function () {
     })
   })
 
+  it('adds dtstart when forceset is applied', () => {
+    const rruleset = rrulestr(
+      'RRULE:FREQ=WEEKLY',
+      {
+        forceset: true,
+        dtstart: new Date(Date.UTC(1997, 8, 2, 9, 0, 0))
+      }
+    )
+
+    expect(rruleset.valueOf()).to.deep.equal([
+      "DTSTART:19970902T090000Z",
+      "RRULE:FREQ=WEEKLY"
+    ])
+  })
+
+  it('adds dtstart from options overriding rule\'s dtstart', () => {
+    const rruleset = rrulestr(
+      'RRULE:DTSTART=19990104T110000Z;FREQ=WEEKLY;BYDAY=TU,WE',
+      {
+        forceset: true,
+        dtstart: new Date(Date.UTC(1997, 8, 2, 9, 0, 0))
+      }
+    )
+
+    expect(rruleset.valueOf()).to.deep.equal([
+      "DTSTART:19970902T090000Z",
+      "RRULE:FREQ=WEEKLY;BYDAY=TU,WE"
+    ])
+  })
+
   it('parses TZID', () => {
     const rrule = rrulestr(
       'DTSTART;TZID=America/New_York:19970902T090000\n' +
@@ -355,7 +385,7 @@ describe('rrulestr', function () {
       "RRULE:FREQ=DAILY;INTERVAL=1",
       "RDATE:20180720T111500Z",
       "EXDATE:20180721T111500Z"
-    ]) 
+    ])
   })
 
   it('parses an RDATE with a TZID param', () => {
@@ -371,7 +401,7 @@ describe('rrulestr', function () {
       "RRULE:FREQ=DAILY;INTERVAL=1",
       "RDATE;TZID=America/Los_Angeles:20180720T111500",
       "EXDATE;TZID=America/Los_Angeles:20180721T111500"
-    ]) 
+    ])
   })
 })
 


### PR DESCRIPTION
This PR fixes a bug which happens when using `rrulestr` in a similar way to this:

```js
rrulestr('RRULE:FREQ=WEEKLY', {
  forceset: true,
  dtstart: new Date()
});
```

In the past (talking `~2.2.0` ish) this would apply `dtstart` and the created rules would have the dtstart. That's no longer the behavior. Having an explicit `dtstart` which could even override the `DTSTART:` specified in the rule was quite convenient, and this PR brings it back.

What's interesting is that this is already the behavior when one doesn't specify `forceset: true`.

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [x] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [x] Written one or more tests showing that your change works as advertised
