### PR TITLE
Chore - Remove yarn from requirements to run the linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build": "yarn lint && tsc && webpack && tsc dist/esm/**/*.d.ts",
-    "lint": "yarn tslint --project . --fix --config tslint.json",
+    "lint": "tslint --project . --fix --config tslint.json",
     "test": "TS_NODE_PROJECT=tsconfig.test.json mocha **/*.test.ts",
     "test-ci": "TS_NODE_PROJECT=tsconfig.test.json nyc mocha **/*.test.ts"
   },


### PR DESCRIPTION
Simple change to allow non-yarn users to run lint via `npm run lint`. This doesn't change the behavior with `yarn` either.


---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [x] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [x] Written one or more tests showing that your change works as advertised
