### PR TITLE
apply timezone offset to test dtstart UTC times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ bower_components/
 coverage
 .nyc_output
 dist/
+
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   },
   "peerDependencies": {},
   "dependencies": {
+    "dayjs": "^1.11.0",
     "tslib": "^1.10.0"
   }
 }

--- a/src/datewithzone.ts
+++ b/src/datewithzone.ts
@@ -1,5 +1,5 @@
-import dateutil from './dateutil'
 import { DateTime } from 'luxon'
+import { dayjs } from './lib/dayjs'
 
 export class DateWithZone {
   public date: Date
@@ -15,12 +15,11 @@ export class DateWithZone {
   }
 
   public toString () {
-    const datestr = dateutil.timeToUntilString(this.date.getTime(), this.isUTC)
     if (!this.isUTC) {
-      return `;TZID=${this.tzid}:${datestr}`
+      return `;TZID=${this.tzid}:${dayjs.tz(this.date, this.tzid).format('YYYYMMDDTHHmmss')}`
     }
 
-    return `:${datestr}`
+    return `:${dayjs(this.date).utc().format('YYYYMMDDTHHmmss')}Z`
   }
 
   public getTime () {

--- a/src/lib/dayjs.ts
+++ b/src/lib/dayjs.ts
@@ -1,0 +1,5 @@
+export const dayjs = require('dayjs')
+const utc = require('dayjs/plugin/utc')
+const timezone = require('dayjs/plugin/timezone') // dependent on utc plugin
+dayjs.extend(utc)
+dayjs.extend(timezone)

--- a/test/optionstostring.test.ts
+++ b/test/optionstostring.test.ts
@@ -7,14 +7,14 @@ describe('optionsToString', () => {
   it('serializes valid single lines of rrules', function () {
     const expectations: ([ Partial<Options>, string ][]) = [
       [{ freq: RRule.WEEKLY, until: new Date(Date.UTC(2010, 0, 1, 0, 0, 0)) }, 'RRULE:FREQ=WEEKLY;UNTIL=20100101T000000Z' ],
-      [{ dtstart: new Date(Date.UTC(1997, 8, 2, 9, 0, 0)), tzid: 'America/New_York' }, 'DTSTART;TZID=America/New_York:19970902T090000' ],
+      [{ dtstart: new Date(Date.UTC(1997, 8, 2, 13, 0, 0)), tzid: 'America/New_York' }, 'DTSTART;TZID=America/New_York:19970902T090000' ],
       [
         { dtstart: new Date(Date.UTC(1997, 8, 2, 9, 0, 0)), freq: RRule.WEEKLY },
         'DTSTART:19970902T090000Z\n' +
         'RRULE:FREQ=WEEKLY'
       ],
       [
-        { dtstart: new Date(Date.UTC(1997, 8, 2, 9, 0, 0)), tzid: 'America/New_York', freq: RRule.WEEKLY },
+        { dtstart: new Date(Date.UTC(1997, 8, 2, 13, 0, 0)), tzid: 'America/New_York', freq: RRule.WEEKLY },
         'DTSTART;TZID=America/New_York:19970902T090000\n' +
         'RRULE:FREQ=WEEKLY'
       ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1091,6 +1091,11 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+dayjs@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.0.tgz#009bf7ef2e2ea2d5db2e6583d2d39a4b5061e805"
+  integrity sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug==
+
 debug@3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"


### PR DESCRIPTION
Issue: https://github.com/jakubroztocil/rrule/issues/501

* Applies timezone offset so that test `dtstart` times are set to 9/2/1997, 9:00:00 AM for `America/New_York`

You can verify with:
```
new Date(Date.UTC(1997, 8, 2, 13, 0, 0)).toLocaleString('en-US', { timeZone: 'America/New_York' })
```