### PR TITLE
fix: Support Jest mocked dates

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,5 +1,5 @@
 import IterResult, { IterArgs } from './iterresult'
-import { clone, cloneDates } from './dateutil'
+import { clone, cloneDates, isDate } from './dateutil'
 import { isArray } from './helpers'
 
 export type CacheKeys = 'before' | 'after' | 'between'
@@ -14,8 +14,8 @@ function argsMatch(
     return left.every((date, i) => date.getTime() === right[i].getTime())
   }
 
-  if (left instanceof Date) {
-    return right instanceof Date && left.getTime() === right.getTime()
+  if (isDate(left)) {
+    return isDate(right) && left.getTime() === right.getTime()
   }
 
   return left === right
@@ -38,7 +38,7 @@ export class Cache {
     args?: Partial<IterArgs>
   ) {
     if (value) {
-      value = value instanceof Date ? clone(value) : cloneDates(value)
+      value = isDate(value) ? clone(value) : cloneDates(value)
     }
 
     if (what === 'all') {
@@ -99,7 +99,7 @@ export class Cache {
 
     return isArray(cached)
       ? cloneDates(cached)
-      : cached instanceof Date
+      : isDate(cached)
       ? clone(cached)
       : cached
   }

--- a/src/dateutil.ts
+++ b/src/dateutil.ts
@@ -66,7 +66,11 @@ export const isLeapYear = function (year: number) {
 }
 
 export const isDate = function (value: unknown): value is Date {
-  return value instanceof Date
+  return (
+    value instanceof Date ||
+    (typeof value === 'object' &&
+      Object.prototype.toString.call(value) === '[object Date]')
+  )
 }
 
 export const isValidDate = function (value: unknown): value is Date {

--- a/src/rruleset.ts
+++ b/src/rruleset.ts
@@ -1,5 +1,5 @@
 import { RRule } from './rrule'
-import { sort, timeToUntilString } from './dateutil'
+import { sort, timeToUntilString, isDate } from './dateutil'
 import { includes } from './helpers'
 import IterResult from './iterresult'
 import { iterSet } from './iterset'
@@ -206,7 +206,7 @@ function _addRule(rrule: RRule, collection: RRule[]) {
 }
 
 function _addDate(date: Date, collection: Date[]) {
-  if (!(date instanceof Date)) {
+  if (!isDate(date)) {
     throw new TypeError(String(date) + ' is not Date instance')
   }
   if (!includes(collection.map(Number), Number(date))) {

--- a/test/lib/utils.ts
+++ b/test/lib/utils.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { ExclusiveTestFunction, TestFunction } from 'mocha'
 export { datetime } from '../../src/dateutil'
-import { datetime } from '../../src/dateutil'
+import { datetime, isDate } from '../../src/dateutil'
 import { RRule, RRuleSet } from '../../src'
 
 const assertDatesEqual = function (
@@ -25,7 +25,7 @@ const assertDatesEqual = function (
   for (let i = 0; i < expected.length; i++) {
     const act = actual[i]
     const exp = expected[i]
-    expect(exp instanceof Date ? exp.toString() : exp).to.equal(
+    expect(isDate(exp) ? exp.toString() : exp).to.equal(
       act.toString(),
       msg + (i + 1) + '/' + expected.length
     )


### PR DESCRIPTION
Jest provides two different implementations of fake timers - legacy and modern. The legacy implementation works with
RRule, while the modern one does not, as it uses a strict instance check. Compare the toString result of the object if
the value is not a Date instance.

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [x] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [ ] Written one or more tests showing that your change works as advertised
