### PR TITLE
Ignore TZID in fully convertible logic.

### DIFF
--- a/src/nlp/totext.ts
+++ b/src/nlp/totext.ts
@@ -139,7 +139,7 @@ export default class ToText {
     if (rrule.origOptions.until && rrule.origOptions.count) return false
 
     for (const key in rrule.origOptions) {
-      if (contains(['dtstart', 'wkst', 'freq'], key)) return true
+      if (contains(['dtstart', 'tzid', 'wkst', 'freq'], key)) return true
       if (!contains(ToText.IMPLEMENTED[rrule.options.freq], key)) return false
     }
 

--- a/test/nlp.test.ts
+++ b/test/nlp.test.ts
@@ -29,6 +29,11 @@ const texts = [
   ['Every week for 20 times', 'RRULE:FREQ=WEEKLY;COUNT=20'],
 ]
 
+const toTexts = [
+  ...texts,
+  ['Every week on monday', 'DTSTART;TZID=America/New_York:20220601T000000\nRRULE:INTERVAL=1;FREQ=WEEKLY;BYDAY=MO'],
+]
+
 describe('NLP', () => {
   it('fromText()', function () {
     texts.forEach(function (item) {
@@ -39,7 +44,7 @@ describe('NLP', () => {
   })
 
   it('toText()', function () {
-    texts.forEach(function (item) {
+    toTexts.forEach(function (item) {
       const text = item[0]
       const str = item[1]
       expect(RRule.fromString(str).toText().toLowerCase()).equals(


### PR DESCRIPTION
Blocked on https://github.com/jakubroztocil/rrule/pull/527.

TZID is fine to ignore, since we never really display any relevant `dtstart` info.