### PR TITLE
Add typesafety to `Weekday.toString()`

### DIFF
--- a/src/weekday.ts
+++ b/src/weekday.ts
@@ -42,7 +42,7 @@ export class Weekday {
   toString() {
     let s: string = ALL_WEEKDAYS[this.weekday]
     if (this.n) s = (this.n > 0 ? '+' : '') + String(this.n) + s
-    return s
+    return s as WeekdayStr
   }
 
   getJsWeekday() {


### PR DESCRIPTION
Currently this type returns `string` rather than `WeekdayStr`.

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [ ] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [ ] Written one or more tests showing that your change works as advertised

Let me know if a test is needed. It's a pretty minor edit.
