### PR TITLE
feat(nlp): support weekly by hour texts

### DIFF
--- a/src/nlp/parsetext.ts
+++ b/src/nlp/parsetext.ts
@@ -134,6 +134,7 @@ export default function parseText(text: string, language: Language = ENGLISH) {
         options.freq = RRule.WEEKLY
         if (ttr.nextSymbol()) {
           ON()
+          AT()
           F()
         }
         break

--- a/src/nlp/parsetext.ts
+++ b/src/nlp/parsetext.ts
@@ -126,6 +126,7 @@ export default function parseText(text: string, language: Language = ENGLISH) {
         options.freq = RRule.WEEKLY
         options.byweekday = [RRule.MO, RRule.TU, RRule.WE, RRule.TH, RRule.FR]
         ttr.nextSymbol()
+        AT()
         F()
         break
 
@@ -198,6 +199,7 @@ export default function parseText(text: string, language: Language = ENGLISH) {
           options.byweekday.push(RRule[wkd] as ByWeekday)
           ttr.nextSymbol()
         }
+        AT()
         MDAYs()
         F()
         break

--- a/src/nlp/totext.ts
+++ b/src/nlp/totext.ts
@@ -281,6 +281,10 @@ export default class ToText {
       } else if (this.byweekday) {
         this._byweekday()
       }
+
+      if (this.origOptions.byhour) {
+        this._byhour()
+      }
     }
   }
 

--- a/test/nlp.test.ts
+++ b/test/nlp.test.ts
@@ -7,7 +7,10 @@ import { datetime } from './lib/utils'
 const texts = [
   ['Every day', 'RRULE:FREQ=DAILY'],
   ['Every day at 10, 12 and 17', 'RRULE:FREQ=DAILY;BYHOUR=10,12,17'],
-  ['Every week on Sunday at 10, 12 and 17', 'RRULE:FREQ=WEEKLY;BYDAY=SU;BYHOUR=10,12,17'],
+  [
+    'Every week on Sunday at 10, 12 and 17',
+    'RRULE:FREQ=WEEKLY;BYDAY=SU;BYHOUR=10,12,17',
+  ],
   ['Every week', 'RRULE:FREQ=WEEKLY'],
   ['Every hour', 'RRULE:FREQ=HOURLY'],
   ['Every 4 hours', 'RRULE:INTERVAL=4;FREQ=HOURLY'],

--- a/test/nlp.test.ts
+++ b/test/nlp.test.ts
@@ -7,6 +7,7 @@ import { datetime } from './lib/utils'
 const texts = [
   ['Every day', 'RRULE:FREQ=DAILY'],
   ['Every day at 10, 12 and 17', 'RRULE:FREQ=DAILY;BYHOUR=10,12,17'],
+  ['Every week on Sunday at 10, 12 and 17', 'RRULE:FREQ=WEEKLY;BYDAY=SU;BYHOUR=10,12,17'],
   ['Every week', 'RRULE:FREQ=WEEKLY'],
   ['Every hour', 'RRULE:FREQ=HOURLY'],
   ['Every 4 hours', 'RRULE:INTERVAL=4;FREQ=HOURLY'],


### PR DESCRIPTION
 e.g. 'every week on Sunday at 10, 12 and 17' would serialize to
 'RRULE:FREQ=WEEKLY;BYDAY=SU;BYHOUR=10,12,17'

Closes #589 

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [x] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [x] Written one or more tests showing that your change works as advertised
