### PR TITLE
expose ALL_WEEKDAYS constant from index file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,6 @@ export { RRuleSet } from './rruleset'
 
 export { rrulestr } from './rrulestr'
 export { Frequency, ByWeekday, Options } from './types'
-export { Weekday, WeekdayStr } from './weekday'
+export { Weekday, WeekdayStr, ALL_WEEKDAYS } from './weekday'
 export { RRuleStrOptions } from './rrulestr'
 export { datetime } from './dateutil'


### PR DESCRIPTION
I would like to utilize the `ALL_WEEKDAYS` constant in my app to create a select with weekdays as options. Would love to hear your thoughts and discuss alternatives if you would like to limit the amount of exports in the index file.

Thank you!
---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [ ] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [ ] Written one or more tests showing that your change works as advertised
