### PR TITLE
Fixed failed to parse sourcemaps error

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": "./dist/esm",
+    "baseUrl": "./src/",
     "outDir": "./dist/esm",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
This fixes the issue surfaced in https://github.com/jakubroztocil/rrule/issues/522 that generates console warnings for anyone who imports rrule into their project.

I've tested it locally in my forked version and it appears to remove the errors.
