### PR TITLE
Patch IOS native date locale appending em to the end of the date string in dateTZtoISO8601

### DIFF
--- a/src/dateutil.ts
+++ b/src/dateutil.ts
@@ -208,7 +208,9 @@ export const dateTZtoISO8601 = function (date: Date, timeZone: string) {
   // date format for sv-SE is almost ISO8601
   const dateStr = date.toLocaleString('sv-SE', { timeZone })
   // '2023-02-07 10:41:36'
-  return dateStr.replace('em', '').trim().replace(' ', 'T') + 'Z'
+  return (
+    dateStr.replace('em', '').replace('fm', '').trim().replace(' ', 'T') + 'Z'
+  )
 }
 
 export const dateInTimeZone = function (date: Date, timeZone: string) {

--- a/src/dateutil.ts
+++ b/src/dateutil.ts
@@ -208,7 +208,7 @@ export const dateTZtoISO8601 = function (date: Date, timeZone: string) {
   // date format for sv-SE is almost ISO8601
   const dateStr = date.toLocaleString('sv-SE', { timeZone })
   // '2023-02-07 10:41:36'
-  return dateStr.replace(' em', '').replace(' ', 'T') + 'Z'
+  return dateStr.replace('em', '').trim().replace(' ', 'T') + 'Z'
 }
 
 export const dateInTimeZone = function (date: Date, timeZone: string) {

--- a/src/dateutil.ts
+++ b/src/dateutil.ts
@@ -208,7 +208,7 @@ const dateTZtoISO8601 = function (date: Date, timeZone: string) {
   // date format for sv-SE is almost ISO8601
   const dateStr = date.toLocaleString('sv-SE', { timeZone })
   // '2023-02-07 10:41:36'
-  return dateStr.replace(' ', 'T') + 'Z'
+  return dateStr.replace(' em', '').replace(' ', 'T') + 'Z'
 }
 
 export const dateInTimeZone = function (date: Date, timeZone: string) {

--- a/src/dateutil.ts
+++ b/src/dateutil.ts
@@ -204,7 +204,7 @@ export const untilStringToDate = function (until: string) {
   )
 }
 
-const dateTZtoISO8601 = function (date: Date, timeZone: string) {
+export const dateTZtoISO8601 = function (date: Date, timeZone: string) {
   // date format for sv-SE is almost ISO8601
   const dateStr = date.toLocaleString('sv-SE', { timeZone })
   // '2023-02-07 10:41:36'

--- a/test/dateutil.test.ts
+++ b/test/dateutil.test.ts
@@ -11,13 +11,28 @@ describe('dateTZtoISO8601', () => {
   it('correctly formats a date with em suffix from toLocaleString', () => {
     // Mock Date.prototype.toLocaleString to simulate iOS behavior
     const originalToLocaleString = Date.prototype.toLocaleString
-    Date.prototype.toLocaleString = jest.fn(() => '2024-01-09 12:00:00 em')
+    Date.prototype.toLocaleString = jest.fn(() => '2045-10-31 1:00:00 em')
 
-    const date = new Date(1704830400000) // The specific date/time
+    const date = new Date()
     const timeZone = 'America/Los_Angeles'
 
     // Your patched function that handles the iOS date string correctly
-    expect(dateTZtoISO8601(date, timeZone)).toBe('2024-01-09T12:00:00Z')
+    expect(dateTZtoISO8601(date, timeZone)).toBe('2045-10-31T1:00:00Z')
+
+    // Restore the original toLocaleString method after the test
+    Date.prototype.toLocaleString = originalToLocaleString
+  })
+
+  it('correctly formats a date with fm suffix from toLocaleString', () => {
+    // Mock Date.prototype.toLocaleString to simulate iOS behavior
+    const originalToLocaleString = Date.prototype.toLocaleString
+    Date.prototype.toLocaleString = jest.fn(() => '2045-10-31 1:00:00 fm')
+
+    const date = new Date()
+    const timeZone = 'America/Los_Angeles'
+
+    // Your patched function that handles the iOS date string correctly
+    expect(dateTZtoISO8601(date, timeZone)).toBe('2045-10-31T1:00:00Z')
 
     // Restore the original toLocaleString method after the test
     Date.prototype.toLocaleString = originalToLocaleString

--- a/test/dateutil.test.ts
+++ b/test/dateutil.test.ts
@@ -1,8 +1,32 @@
-import { datetime, untilStringToDate } from '../src/dateutil'
+import { datetime, untilStringToDate, dateTZtoISO8601 } from '../src/dateutil'
 
 describe('untilStringToDate', () => {
   it('parses a date string', () => {
     const date = untilStringToDate('19970902T090000')
     expect(date.getTime()).toBe(datetime(1997, 9, 2, 9, 0, 0).getTime())
+  })
+})
+
+describe('dateTZtoISO8601', () => {
+  it('correctly formats a date with em suffix from toLocaleString', () => {
+    // Mock Date.prototype.toLocaleString to simulate iOS behavior
+    const originalToLocaleString = Date.prototype.toLocaleString
+    Date.prototype.toLocaleString = jest.fn(() => '2024-01-09 12:00:00 em')
+
+    const date = new Date(1704830400000) // The specific date/time
+    const timeZone = 'America/Los_Angeles'
+
+    // Your patched function that handles the iOS date string correctly
+    expect(dateTZtoISO8601(date, timeZone)).toBe('2024-01-09T12:00:00Z')
+
+    // Restore the original toLocaleString method after the test
+    Date.prototype.toLocaleString = originalToLocaleString
+  })
+
+  it('formats a date in ISO8601 format for non-iOS environments', () => {
+    const date = new Date(1704830400000)
+    const timeZone = 'America/Los_Angeles'
+    // This tests the function in environments that do not have the ' em' issue
+    expect(dateTZtoISO8601(date, timeZone)).toBe('2024-01-09T12:00:00Z')
   })
 })


### PR DESCRIPTION
On IOS, the sweden locale looks like this (with the native date library):
'2024-01-09 12:00:00 em'
but with the nodejs date its:
'2024-01-09T12:00:00Z'

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [ ] Linked to an existing bug or issue describing the bug or feature you're
      addressing
    - couldn't find a bug for this yet
- [x] Written one or more tests showing that your change works as advertised
