### PR TITLE
chore(corepack): specify package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,5 +87,6 @@
   "peerDependencies": {},
   "dependencies": {
     "tslib": "^2.4.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
This property allows to directly use the correct package manager for this project, speeds up contributions and adds flexibility.
